### PR TITLE
Improvement of db_helper for sqlite support 

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,6 @@
 sh ./src/server/migrations/import_metadata.sh
 
+sudo apt-get update
 sudo pip install -r requirements.txt
 
 sudo apt-get install python3-dev libgraphviz-dev 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,16 @@
 sh ./src/server/migrations/import_metadata.sh
 
 sudo apt-get update
-sudo pip install -r requirements.txt
+sudo apt-get install python3-venv
 
-sudo apt-get install python3-dev libgraphviz-dev 
-sudo pip install -r src/server/sql_graph/requirements.txt
+# Create and activate a virtual environment (without sudo)
+python3 -m venv venv
+source venv/bin/activate
+
+# Install dependencies inside the virtual environment (without sudo)
+pip3 install -r requirements.txt
+
+# Additional installations (without sudo)
+sudo apt-get install python3-dev libgraphviz-dev
+pip3 install -r src/server/sql_graph/requirements.txt
+python3 src/server/app.py

--- a/src/server/db/db_helper.py
+++ b/src/server/db/db_helper.py
@@ -438,9 +438,15 @@ class postgresql_database(Database):
             # return False
 
 class sqlite_database(Database):
+    def __init__(self):
+        self.temp_db_folder = "temporary_db"
+        if not os.path.exists(self.temp_db_folder):
+            os.makedirs(self.temp_db_folder)
+
     async def get_connection(self):
         try:
-            con = sqlite3.connect("temp.db")
+            db_file_path = os.path.join(self.temp_db_folder, "temp.db")
+            con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             return cursor, con
         except Exception as e:
@@ -449,7 +455,8 @@ class sqlite_database(Database):
 
     async def create_database_and_schema(self, db_name):
         try:
-            con = sqlite3.connect(f'{db_name}.db')
+            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             con.commit()
             return True, ""
@@ -459,7 +466,8 @@ class sqlite_database(Database):
     
     async def create_schema_in_db(self, db_name, schema):
         try:
-            con = sqlite3.connect(f'{db_name}.db')
+            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             # Split the SQL dump into separate statements
             schema = schema.decode('UTF-8')
@@ -488,7 +496,8 @@ class sqlite_database(Database):
 
     async def get_tables_from_schema_id(self, schema_id):
         try:
-            con = sqlite3.connect(f'{db_name}.db')
+            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             cursor.execute(f"SELECT name FROM sqlite_master WHERE type='table';")
             table_meta = cursor.fetchall()
@@ -500,7 +509,8 @@ class sqlite_database(Database):
     
     async def get_table_info(self, db_name, table_name):
         try:
-            con = sqlite3.connect(f'{db_name}.db')
+            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            con = sqlite3.connect(db_file_path)
             cur = con.cursor()
             cur.execute(f"PRAGMA table_info({table_name});")
             columns = cur.fetchall()
@@ -544,7 +554,8 @@ class sqlite_database(Database):
     
     async def validate_sql(self, db_name, query):
         try:
-            con = sqlite3.connect(f'{db_name}.db')
+            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            con = sqlite3.connect(db_file_path)
             cur = con.cursor()
             cur.execute(query)
             metadata = []

--- a/src/server/db/db_helper.py
+++ b/src/server/db/db_helper.py
@@ -472,7 +472,7 @@ class sqlite_database(Database):
             # Split the SQL dump into separate statements
             schema = schema.decode('UTF-8')
             # Remove comments from the SQL dump
-            schema = re.sub(r'(--[^\n]*|/\*.*?\*/)', '', schema)
+            schema = re.sub(r'(--[^\n]*|/\*.*?\*/|(?:[^;\'"]|\'[^\']*\'|"[^"]*")*;)', '', schema)
             sql_commands = schema.split(';')
 
             # Execute each statement

--- a/src/server/db/db_helper.py
+++ b/src/server/db/db_helper.py
@@ -450,14 +450,7 @@ class sqlite_database(Database):
             os.makedirs(self.sqlite_db_folder)
 
     async def get_connection(self):
-        try:
-            db_file_path = os.path.join(self.sqlite_db_folder, "temp.db")
-            con = sqlite3.connect(db_file_path)
-            cursor = con.cursor()
-            return cursor, con
-        except Exception as e:
-            logging.error(f"ERROR: {e}, {traceback.print_exc()}")
-            raise Exception("Failed to connect to db")
+        pass
 
     async def create_database_and_schema(self, db_name):
         try:

--- a/src/server/db/db_helper.py
+++ b/src/server/db/db_helper.py
@@ -495,7 +495,7 @@ class sqlite_database(Database):
 
     async def get_tables_from_schema_id(self, schema_id):
         try:
-            db_file_path = os.path.join(self.sqlite_db_folder, f'{db_name}.db')
+            db_file_path = os.path.join(self.sqlite_db_folder, f'{schema_id}.db')
             con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             cursor.execute(f"SELECT name FROM sqlite_master WHERE type='table';")

--- a/src/server/db/db_helper.py
+++ b/src/server/db/db_helper.py
@@ -439,13 +439,19 @@ class postgresql_database(Database):
 
 class sqlite_database(Database):
     def __init__(self):
-        self.temp_db_folder = "temporary_db"
-        if not os.path.exists(self.temp_db_folder):
-            os.makedirs(self.temp_db_folder)
+        root_folder = "files"
+        db_folder = "sqlite_db"
+        self.sqlite_db_folder = os.path.join(root_folder, db_folder)
+
+        if not os.path.exists(root_folder):
+            os.makedirs(root_folder)
+
+        if not os.path.exists(self.sqlite_db_folder):
+            os.makedirs(self.sqlite_db_folder)
 
     async def get_connection(self):
         try:
-            db_file_path = os.path.join(self.temp_db_folder, "temp.db")
+            db_file_path = os.path.join(self.sqlite_db_folder, "temp.db")
             con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             return cursor, con
@@ -455,7 +461,7 @@ class sqlite_database(Database):
 
     async def create_database_and_schema(self, db_name):
         try:
-            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            db_file_path = os.path.join(self.sqlite_db_folder, f'{db_name}.db')
             con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             con.commit()
@@ -466,7 +472,7 @@ class sqlite_database(Database):
     
     async def create_schema_in_db(self, db_name, schema):
         try:
-            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            db_file_path = os.path.join(self.sqlite_db_folder, f'{db_name}.db')
             con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             # Split the SQL dump into separate statements
@@ -496,7 +502,7 @@ class sqlite_database(Database):
 
     async def get_tables_from_schema_id(self, schema_id):
         try:
-            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            db_file_path = os.path.join(self.sqlite_db_folder, f'{db_name}.db')
             con = sqlite3.connect(db_file_path)
             cursor = con.cursor()
             cursor.execute(f"SELECT name FROM sqlite_master WHERE type='table';")
@@ -509,7 +515,7 @@ class sqlite_database(Database):
     
     async def get_table_info(self, db_name, table_name):
         try:
-            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            db_file_path = os.path.join(self.sqlite_db_folder, f'{db_name}.db')
             con = sqlite3.connect(db_file_path)
             cur = con.cursor()
             cur.execute(f"PRAGMA table_info({table_name});")
@@ -554,7 +560,7 @@ class sqlite_database(Database):
     
     async def validate_sql(self, db_name, query):
         try:
-            db_file_path = os.path.join(self.temp_db_folder, f'{db_name}.db')
+            db_file_path = os.path.join(self.sqlite_db_folder, f'{db_name}.db')
             con = sqlite3.connect(db_file_path)
             cur = con.cursor()
             cur.execute(query)


### PR DESCRIPTION
Earlier db_helper for sqlite support was storing the temporary db in the root directory. After this PR it will store the temporary db files in a temporary directory that can be deleted later. 

Regex has also been improved in create_schema_for_db to take care of the case when semi-colon (;) may be present inside the query. 